### PR TITLE
Add upload file support.

### DIFF
--- a/src/WordPressSharp/IWordPressService.cs
+++ b/src/WordPressSharp/IWordPressService.cs
@@ -19,6 +19,9 @@ namespace WordPressSharp
         [XmlRpcMethod("wp.getMediaLibrary")]
         MediaItem[] GetMediaLibrary(int blog_id, string username, string password, MediaFilter filter);
 
+        [XmlRpcMethod("wp.uploadFile")]
+        UploadResult UploadFile(int blog_id, string username, string password, Data upload);
+
         [XmlRpcMethod("wp.getTaxonomy")]
         Taxonomy GetTaxonomy(int blog_id, string username, string password, string taxonomy, int term_id);
 

--- a/src/WordPressSharp/Models/MediaUpload.cs
+++ b/src/WordPressSharp/Models/MediaUpload.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using CookComputing.XmlRpc;
+
+namespace WordPressSharp.Models
+{
+    public class UploadResult
+    {
+
+        public string id { get; set; }        
+        [XmlRpcMember("file")]
+        public string file { get; set; }
+        [XmlRpcMember("url")]
+        public string url { get; set; }
+        [XmlRpcMember("type")]
+        public string type { get; set; }
+    }
+
+    public class Data {
+        [XmlRpcMember("name")]
+        public string Name { get; set; }
+        [XmlRpcMember("type")]
+        public string Type { get; set; }
+        /// <summary>
+        /// Pass an array of bytes IE File.ReadAllBytes(filepath)
+        /// </summary>
+        [XmlRpcMember("bits")]       
+        public byte[] Bits { get; set; }
+        [XmlRpcMember("overwrite")]
+        public bool Overwrite { get; set; }
+        [XmlRpcMember("post_id")]
+        public int post_id { get; set; }
+    }
+
+    [XmlRpcMissingMapping(MappingAction.Ignore)]
+    public class MediaUpload
+    {
+        public Data data { get; set; }
+    }
+}

--- a/src/WordPressSharp/WordPressClient.cs
+++ b/src/WordPressSharp/WordPressClient.cs
@@ -61,6 +61,16 @@ namespace WordPressSharp
         }
 
         /// <summary>
+        /// Upload a file
+        /// </summary>
+        /// <param name="upload">Upload data</param>
+        /// <returns></returns>
+        public UploadResult UploadFile(Data upload)
+        {
+            return WordPressService.UploadFile(WordPressSiteConfig.BlogId, WordPressSiteConfig.Username, WordPressSiteConfig.Password, upload);
+        }
+
+        /// <summary>
         /// Gets a media library by Media Filter
         /// </summary>
         /// <param name="filter">Media Filter</param>

--- a/src/WordPressSharp/WordPressSharp.csproj
+++ b/src/WordPressSharp/WordPressSharp.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Models\MediaItemMetadata.cs" />
     <Compile Include="Models\MediaItemSizes.cs" />
     <Compile Include="Models\MediamItemSize.cs" />
+    <Compile Include="Models\MediaUpload.cs" />
     <Compile Include="Models\Option.cs" />
     <Compile Include="Models\Option_Get.cs" />
     <Compile Include="Models\Post.cs" />


### PR DESCRIPTION
This is the basic functionality working. I have been experimenting with moving it into a task with a delegate call back at completion because it is a somewhat long process, especially if the image is large but I am not far enough along in that testing wise to include that and don't know if you want to do that or relegate that to the end user.


**Simple sample of using it**
WordPressClient client = new WordPressClient(new WordPressSiteConfig()
            {
                BaseUrl = "url",
                Username = "username",
                Password = "password"
            });
            using (OpenFileDialog openDialog = new OpenFileDialog())
            {
                openDialog.Filter = "Image Files (*.jpg;*.jpeg;*.png;*.gif|*.jpg;*.jpeg;*.png;*.gif|All Files (*.*)|*.*";
                openDialog.Multiselect = true;
                if (openDialog.ShowDialog() == DialogResult.OK && openDialog.FileNames.Length > 0)
                {
                    foreach (string fileName in openDialog.FileNames)
                    {
                        try
                        {
                            client.UploadFile(new Data()
                            {
                                Name = Path.GetFileName(fileName),
                                Overwrite = true,
                                Type = "image/jpeg",
                                Bits = File.ReadAllBytes(fileName)
                            });
                        }
                        catch { }
                    }
                }
            }