### PR TITLE
class name typo?

### DIFF
--- a/src/WordPressSharp/Models/MediamItemSize.cs
+++ b/src/WordPressSharp/Models/MediamItemSize.cs
@@ -3,7 +3,7 @@
 namespace WordPressSharp.Models
 {
     [XmlRpcMissingMapping(MappingAction.Ignore)]
-    public class MediamItemSize
+    public class MediaItemSize
     {
         [XmlRpcMember("file")]
         public string File { get; set; }


### PR DESCRIPTION
I noticed the class name was "MediamItemSize" . I suppose that's a typo, I suggest a change to "MediaItemSize", one I made locally for "GetMediaItem" method to work properly.