### PR TITLE
Wrong member declaration type

### DIFF
--- a/src/WordPressSharp/Models/MediaItemSizes.cs
+++ b/src/WordPressSharp/Models/MediaItemSizes.cs
@@ -6,21 +6,21 @@ namespace WordPressSharp.Models
     public class MediaItemSizes
     {
         [XmlRpcMember("medium")]
-        public MediaItemSizes Medium { get; set; }
+        public MediaItemSize Medium { get; set; }
 
         [XmlRpcMember("large")]
-        public MediaItemSizes Large { get; set; }
+        public MediaItemSize Large { get; set; }
 
         [XmlRpcMember("thumbnail")]
-        public MediaItemSizes Thumbnail { get; set; }
+        public MediaItemSize Thumbnail { get; set; }
 
-        [XmlRpcMember("post_thumbnail")]
-        public MediaItemSizes PostThumbnail { get; set; }
+        [XmlRpcMember("post-thumbnail")]
+        public MediaItemSize PostThumbnail { get; set; }
 
         [XmlRpcMember("listing")]
-        public MediaItemSizes Listing { get; set; }
+        public MediaItemSize Listing { get; set; }
 
         [XmlRpcMember("listing_small")]
-        public MediaItemSizes ListingSmall { get; set; }
+        public MediaItemSize ListingSmall { get; set; }
     }
 }


### PR DESCRIPTION
I noticed sized were being returned as null in my test project. that's because of the wrong member declaration.

I think members should be of type "MediaItemSize" (see change request for typo in that class also)

Also, [XmlRpcMember("post_thumbnail")] on Line 17 is not correct. Rest of members were returning ok, but this one was still returning null. I looked over the XML RPC api for wordpress and it is called "post-thumbnail" (dash instead of underline).

Hope this helps.