### PR TITLE
Issue #33 fixed

### DIFF
--- a/src/WordPressSharp/Models/Post.cs
+++ b/src/WordPressSharp/Models/Post.cs
@@ -47,7 +47,8 @@ namespace WordPressSharp.Models
 
         [XmlRpcMember("post_parent")]
         public string ParentId { get; set; }
+        
         [XmlRpcMember("post_thumbnail")]
-        public string FeaturedImageId { get; set; }
+        public MediaItem[] FeaturedImageId { get; set; }
     }
 }


### PR DESCRIPTION
Unhandled exception 
"An unhandled exception of type 'CookCompu...ting.XmlRpc.XmlRpcTypeMismatchException' occurred in CookComputing.XmlRpcV2.dll
Additional information: response contains array value where string expected [response : struct mapped to type Post : member FeaturedImageId mapped to type String]"
was fixed.