### PR TITLE
Fixed FeaturedItemId for new posts. "Fixed" error for GetPost(s).

### DIFF
--- a/src/WordPressSharp/Models/MediaUpload.cs
+++ b/src/WordPressSharp/Models/MediaUpload.cs
@@ -7,17 +7,36 @@ using CookComputing.XmlRpc;
 
 namespace WordPressSharp.Models
 {
-    public class UploadResult
-    {
+	public class UploadResult
+	{
+		[XmlRpcMember("id")]
+		public string Id { get; set; }
 
-        public string id { get; set; }        
-        [XmlRpcMember("file")]
-        public string file { get; set; }
-        [XmlRpcMember("url")]
-        public string url { get; set; }
-        [XmlRpcMember("type")]
-        public string type { get; set; }
-    }
+		[XmlRpcMember("file")]
+		public string File { get; set; }
+
+		[XmlRpcMember("url")]
+		public string Url { get; set; }
+
+		[XmlRpcMember("type")]
+		public string Type { get; set; }
+
+		#region obsoletes
+
+		[Obsolete("Please use Id")]
+		public string id { get { return Id; } set { Id = value; } }
+
+		[Obsolete("Please use File")]
+		public string file { get { return File; } set { File = value; } }
+
+		[Obsolete("Please use Url")]
+		public string url { get { return Url; } set { Url = value; } }
+
+		[Obsolete("Please use Type")]
+		public string type { get { return Type; } set { Type = value; } }
+
+		#endregion
+	}
 
     public class Data {
         [XmlRpcMember("name")]

--- a/src/WordPressSharp/Models/Post.cs
+++ b/src/WordPressSharp/Models/Post.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using CookComputing.XmlRpc;
+using System.Diagnostics;
 
 namespace WordPressSharp.Models
 {
+    [DebuggerDisplay("{GetType().Name,nq}: Id={Id, nq}, Title={Title}")]
     [XmlRpcMissingMapping(MappingAction.Ignore)]
     public class Post
     {
@@ -48,8 +50,7 @@ namespace WordPressSharp.Models
         [XmlRpcMember("post_parent")]
         public string ParentId { get; set; }
         
-        [XmlRpcMember("post_thumbnail")]
-        public MediaItem[] FeaturedImageId { get; set; }
+		public string FeaturedImageId { get; set; }
         
         [XmlRpcMember("post_excerpt")]
         public string Exerpt { get; set; }

--- a/src/WordPressSharp/Models/Post_Put.cs
+++ b/src/WordPressSharp/Models/Post_Put.cs
@@ -1,12 +1,10 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using CookComputing.XmlRpc;
+using System;
+using System.Diagnostics;
 
 namespace WordPressSharp.Models
 {
+    [DebuggerDisplay("{GetType().Name,nq}: Id={Id, nq}, Title={Title}")]
     [XmlRpcMissingMapping(MappingAction.Ignore)]
     public class Post_Put
     {
@@ -37,7 +35,6 @@ namespace WordPressSharp.Models
         [XmlRpcMember("link")]
         public string Link { get; set; }
 
-
         [XmlRpcMember("custom_fields")]
         public CustomField[] CustomFields { get; set; }
 
@@ -55,7 +52,6 @@ namespace WordPressSharp.Models
 
         [XmlRpcMember("post_thumbnail")]
         public string FeaturedImageId { get; set; }
-
 
         /*[XmlRpcMember("terms_names")]
         public XmlRpcStruct TermsNames { get; set; }*/


### PR DESCRIPTION
- Added a debugger displays for easier debugging. Very handy in lists.
- Removed the XmlRpcMember("post_thumbnail"). This parameter currently gives problems when all posts are queried. It looks like sometimes it is an array and sometimes it is a struct. Changed the type the FeaturedImageId is used by Post_Put and it is only copied when name and type are the same (so it wasn't copied).
- Refactored UploadResult (casing)

Note:
- The post_tumbnail and FeaturedImageId data look very different. The one is the object, the other is the entire object.